### PR TITLE
Add support for passage (in addition to pass)

### DIFF
--- a/jayrah/config.py
+++ b/jayrah/config.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import click
+import re
 import yaml
 from rich.prompt import Prompt
 
@@ -63,9 +64,10 @@ def read_config(ret: dict, config_file: pathlib.Path) -> dict:
         if (
             "jira_password" in ret
             and ret["jira_password"]
-            and ret["jira_password"].startswith("pass::")
+            and re.match(r"(pass|passage)::", ret["jira_password"])
         ):
             ret["jira_password"] = utils.get_pass_key(
+                ret["jira_password"].split("::")[0],
                 ret["jira_password"].split("::")[-1]
             )
 

--- a/jayrah/utils.py
+++ b/jayrah/utils.py
@@ -76,8 +76,8 @@ def parse_email(dico):
     return s.split("@")[0].split("+")[0]
 
 
-def get_pass_key(s):
-    cmd = ["pass", "show", s]
+def get_pass_key(passCmd, s):
+    cmd = [passCmd, "show", s]
     try:
         return subprocess.check_output(cmd, text=True).strip()
     except subprocess.CalledProcessError:


### PR DESCRIPTION
This is the same "cli" UX *but* the command differs.
This would allow the use to use `passage:path/to/token` (like
`pass:path/to/token`).

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
