### PR TITLE
Fix CLI option help text

### DIFF
--- a/jayrah/commands/common.py
+++ b/jayrah/commands/common.py
@@ -28,12 +28,12 @@ from ..ui import boards
 @click.option(
     "--jira-component",
     default=os.environ.get("JIRA_COMPONENT"),
-    help="Jira user",
+    help="Jira component",
 )
 @click.option(
     "--jira-password",
     default=os.environ.get("JIRA_PASSWORD"),
-    help="Jira user",
+    help="Jira password",
 )
 @click.option("--cache-ttl", "-t", help="Cache TTL in seconds")
 @click.option(

--- a/misc/completion.bash
+++ b/misc/completion.bash
@@ -9,8 +9,8 @@ Options:
   --insecure              Disable SSL verification for requests
   --jira-server TEXT      Jira server URL
   --jira-user TEXT        Jira user
-  --jira-component TEXT   Jira user
-  --jira-password TEXT    Jira user
+  --jira-component TEXT   Jira component
+  --jira-password TEXT    Jira password
   -t, --cache-ttl TEXT    Cache TTL in seconds
   -c, --config-file TEXT  Config file to use
   --help                  Show this message and exit.


### PR DESCRIPTION
## Summary
- correct labels for Jira component and password in bash completion script
- fix mislabeled option help text in `commands/common.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685b8b84ac6c832d82f75b8a9b7e0720