### PR TITLE
Fix markdown wrapper for java fences

### DIFF
--- a/jayrah/utils/issue_view.py
+++ b/jayrah/utils/issue_view.py
@@ -45,7 +45,8 @@ def wrap_markdown(text):
     lines = []
     for line in text.split("\n"):
         # Skip wrapping for code blocks and headers
-        if line.endswith("```java"):
+        # Convert ```java fenced blocks to bash for better rendering
+        if line.startswith("```java"):
             line = "```bash"
 
         if line.startswith("```") or line.startswith("#"):


### PR DESCRIPTION
## Summary
- fix detection of java code blocks in `wrap_markdown`
- comment clarifying the conversion

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685b8b772cd0832d87f41074c5008680